### PR TITLE
update developer docs

### DIFF
--- a/capytaine/__about__.py
+++ b/capytaine/__about__.py
@@ -4,7 +4,7 @@ __all__ = ["__title__", "__description__", "__version__", "__author__", "__uri__
 __title__ = "capytaine"
 __description__ = """Python BEM solver for linear potential flow, based on Nemoh"""
 
-__version__ = "1.2"
+__version__ = "1.2.1"
 
 __author__ = "Matthieu Ancellin"
 __uri__ = "https://github.com/mancellin/capytaine"

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -60,3 +60,7 @@ You will also likely want to install Capytaine's optional dependencies::
 
 	conda install matplotlib vtk pytest quadpy
 	pip install pygmsh 
+
+For instructions about how to help with the development of Capytaine, see the `contributing guide`_.
+
+.. _`contributing guide`: https://github.com/mancellin/capytaine/blob/master/CONTRIBUTING.md

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -3,7 +3,7 @@ Installation for developers
 ===========================
 
 Capytaine requires **Python 3.6** or higher.
-It has been successfully tested on Python 3.6 and 3.7, and Numpy 1.15 and 1.16.
+It has been successfully tested on Python 3.6, 3.7, and 3.9, and Numpy 1.15, 1.16, and 1.20.
 
 It is recommended to use a `conda environment`_.
 

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -15,10 +15,10 @@ Ensure that Numpy is installed in your enviroment::
 
 You'll also need a Fortran compiler:
 
-* On Linux, you can install `gfortran` with the package manager of your distribution (e.g. `sudo apt install gfortran`).
+* **On Linux,** you can install :code:`gfortran` with the package manager of your distribution (e.g. :code:`sudo apt install gfortran`).
 
-* On Windows, the code can be compiled with MinGW.
-  Add the directory with the `gfortran` binary to your path. For instance with `set PATH=C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;%PATH%`.
+* **On Windows,** the code can be compiled with MinGW.
+  Add the directory with the `gfortran` binary to your path. For instance with :code:`set PATH=C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;%PATH%`.
   You should also let Python know about the compiler by creating a file with the following two lines::
 
     echo [build]

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -26,6 +26,18 @@ You'll also need a Fortran compiler:
 
   as `C:\\path\\to\\anaconda\\Lib\\distutils\\distutils.cfg`.
 
+* **On macOS,** you can install the required compilers via `Homebrew`_. Make sure that
+  the compilers installed by Homebrew are in you path (e.g., :code:`which gcc`); 
+  this can be accomplished by adding the relevant directories to your path::
+
+  	export PATH="/usr/local/bin:$PATH"
+
+  or through the use of aliases, e.g.,::
+  
+  	alias gcc=/usr/local/bin/gcc-10
+  
+.. _`Homebrew`: https://brew.sh
+
 Then, download the source code from Github web interface or using ``git`` with::
 
     git clone https://github.com/mancellin/capytaine

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -55,3 +55,8 @@ Add the current directory to the Python path with the following command::
 (This last two commands are included into the ``Makefile`` of the main directory.
 They can be run by ``make develop``.
 The command ``make clean`` deletes the binaries.)
+
+You will also likely want to install Capytaine's optional dependencies::
+
+	conda install matplotlib vtk pytest quadpy
+	pip install pygmsh 

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -58,8 +58,8 @@ The command ``make clean`` deletes the binaries.)
 
 You will also likely want to install Capytaine's optional dependencies::
 
-	conda install matplotlib vtk pytest quadpy
-	pip install pygmsh 
+	conda install matplotlib vtk pytest quadpy hypothesis ipython
+	pip install pygmsh
 
 For instructions about how to help with the development of Capytaine, see the `contributing guide`_.
 


### PR DESCRIPTION
This adds instructions for compiling on macOS (fixes #31) and makes a couple other minor improvements/updates to the [Installation for developers](https://ancell.in/capytaine/latest/developer_manual/installation.html#installation-for-developers) documentation page.