### PR TITLE
Hydrostatics for RAO

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 New in next version
 ---------------------------------
 
+* Add example in cookbook for computing hydrostatics and mass properties
 * Break out impedance from RAO to separate function (see #61`<https://github.com/mancellin/capytaine/issues/61>`_ and (see #63`<https://github.com/mancellin/capytaine/pull/63>`_)
 
 ---------------------------------

--- a/docs/user_manual/cookbook.rst
+++ b/docs/user_manual/cookbook.rst
@@ -46,6 +46,12 @@ Simulation with several bodies
 .. literalinclude:: examples/multibody.py
    :language: python
 
+Adding hydrostatic stiffness and mass properties
+------------------------------------------------
+Hydrostatic and inertia propoerties can be computed via Meshmagick for use with the hydrodynamic results generated with Capytaine.
+
+.. literalinclude:: examples/hydrostatics.py
+   :language: python
 
 Intermediate examples
 =====================

--- a/docs/user_manual/examples/boat_animation.py
+++ b/docs/user_manual/examples/boat_animation.py
@@ -31,9 +31,9 @@ def generate_boat() -> cpt.FloatingBody:
     # The computation of the RAO requires the values of the inertia matrix and the hydrostatic stiffness matrix.
     # They need to be computed independently.
     boat.mass = boat.add_dofs_labels_to_matrix(
-        [[1e4, 0,   0,   0,   0,   0],
-         [0,   1e4, 0,   0,   0,   0],
-         [0,   0,   1e4, 0,   0,   0],
+        [[1e6, 0,   0,   0,   0,   0],
+         [0,   1e6, 0,   0,   0,   0],
+         [0,   0,   1e6, 0,   0,   0],
          [0,   0,   0,   1e7, 0,   2e5],
          [0,   0,   0,   0,   4e7, 0],
          [0,   0,   0,   2e5, 0,   5e7]]

--- a/docs/user_manual/examples/boat_animation.py
+++ b/docs/user_manual/examples/boat_animation.py
@@ -7,6 +7,10 @@ from numpy import pi
 import capytaine as cpt
 from capytaine.ui.vtk import Animation
 
+from meshmagick import mesh as mm
+from meshmagick import hydrostatics as hs
+from scipy.linalg import block_diag
+
 logging.basicConfig(level=logging.INFO, format='%(levelname)-8s: %(message)s')
 
 bem_solver = cpt.BEMSolver()
@@ -28,14 +32,11 @@ def generate_boat() -> cpt.FloatingBody:
          [0,   0,   0,   0,   4e7, 0],
          [0,   0,   0,   2e5, 0,   5e7]]
     )
-    boat.hydrostatic_stiffness = boat.add_dofs_labels_to_matrix(
-        [[0, 0, 0,    0,   0,    0],
-         [0, 0, 0,    0,   0,    0],
-         [0, 0, 3e6,  0,   -7e6, 0],
-         [0, 0, 0,    2e7, 0,    0],
-         [0, 0, -7e6, 0,   1e8,  0],
-         [0, 0, 0,    0,   0,    0]]
-    )
+
+    # You can use Meshmagick to compute the hydrostatic stiffness matrix.
+    hsd = hs.Hydrostatics(mm.Mesh(boat.mesh.vertices, boat.mesh.faces)).hs_data
+    kHS = block_diag(0,0,hsa['stiffness_matrix'],0)
+    boat.hydrostatic_stiffness = boat.add_dofs_labels_to_matrix(kHS)
     return boat
 
 

--- a/docs/user_manual/examples/boat_animation.py
+++ b/docs/user_manual/examples/boat_animation.py
@@ -7,7 +7,6 @@ from numpy import pi
 import capytaine as cpt
 from capytaine.ui.vtk import Animation
 
-from capytaine.tools.optional_imports import import_optional_dependency
 try:
     import meshmagick.hydrostatics as hs
     import meshmagick.mesh as mm

--- a/docs/user_manual/examples/hydrostatics.py
+++ b/docs/user_manual/examples/hydrostatics.py
@@ -1,0 +1,51 @@
+
+import logging
+import capytaine as cpt
+
+import numpy as np
+np.set_printoptions(precision=3)
+np.set_printoptions(linewidth=160)
+
+import meshmagick.hydrostatics as hs
+import meshmagick.mesh as mm
+
+from scipy.linalg import block_diag
+
+rho_water = 1025
+g = 9.81
+
+# Initialize floating body
+r = 1.0
+sphere = cpt.Sphere(
+    radius=r,          # Dimension
+    center=(0, 0, 0),    # Position
+    nphi=20, ntheta=20,  # Fineness of the mesh
+)
+sphere.add_all_rigid_body_dofs()
+
+# Visualize the body
+# sphere.show()
+
+# Create a hydrostatics body in Meshmagick
+hsd = hs.Hydrostatics(mm.Mesh(sphere.mesh.vertices, sphere.mesh.faces),
+					  cog=(0,0,0),
+					  rho_water=rho_water,
+					  grav=g).hs_data
+
+# Inertial properties for neutrally buoyant constant density body
+m = hsd['disp_mass']
+I = np.array([[hsd['Ixx'], -1*hsd['Ixy'], -1*hsd['Ixz']],
+              [-1*hsd['Ixy'], hsd['Iyy'], -1*hsd['Iyz']],
+              [-1*hsd['Ixz'], -1*hsd['Iyz'], hsd['Izz']]])
+M = block_diag(m, m, m, I)
+sphere.mass = sphere.add_dofs_labels_to_matrix(M)
+print(sphere.mass)
+
+assert np.isclose(m, 1/2 * 4/3 * r**3 * np.pi * rho_water, rtol=1e-1)
+
+# Hydrostatics
+kHS = block_diag(0,0,hsd['stiffness_matrix'],0)
+sphere.hydrostatic_stiffness = sphere.add_dofs_labels_to_matrix(kHS)
+
+print(sphere.hydrostatic_stiffness)
+assert np.isclose(kHS[2,2], r**2 * np.pi * rho_water * g, rtol=1e-1)


### PR DESCRIPTION
There are a number of discussions/requests about computing hydrostatics (#64, #36, #55, #66). However, as noted in #64 including automated calculation of hydrostatics in `capytaine` is not so easy, as it support generalized modes. This PR updates the [`boat_animation`](https://github.com/mancellin/capytaine/blob/87d09bf56dcd1d4a242a29805e9d49511b3947e1/docs/user_manual/examples/boat_animation.py) example to show how the hydrostatics can be computed using [`meshmagick`](https://github.com/LHEEA/meshmagick) if desired.

closes #64 #66