### PR TITLE
fixed FutureWarning in _dataset_from_dataframe function

### DIFF
--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -137,7 +137,7 @@ def _dataset_from_dataframe(df: pd.DataFrame,
         more than one different values.
     """
     for variable_name in variables:
-        df = df[df[variable_name].notnull()].dropna(1)  # Keep only records with non null values of all the variables
+        df = df[df[variable_name].notnull()].dropna(axis='columns')  # Keep only records with non null values of all the variables
     df = df.drop_duplicates()
     df = df.set_index(optional_dims + dimensions)
 


### PR DESCRIPTION
This resolves the FutureWarning of Pandas.DataFrame.dropna. 

`FutureWarning: In a future version of pandas all arguments of DataFrame.dropna will be keyword-only`.
