### PR TITLE
Potential evaluation for arbitrary number of mesh faces

### DIFF
--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -194,7 +194,7 @@ class BEMSolver:
         else:
             phi = np.empty((mesh.nb_faces,), dtype=np.complex128)
             for i in range(0, mesh.nb_faces, chunk_size):
-		faces_to_extract = list(range(i, min(i+chunk_size, mesh.nb_faces)))
+                faces_to_extract = list(range(i, min(i+chunk_size, mesh.nb_faces)))
                 S = self.engine.build_S_matrix(
                     mesh.extract_faces(faces_to_extract),
                     result.body.mesh,

--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -194,8 +194,9 @@ class BEMSolver:
         else:
             phi = np.empty((mesh.nb_faces,), dtype=np.complex128)
             for i in range(0, mesh.nb_faces, chunk_size):
+		faces_to_extract = list(range(i, min(i+chunk_size, mesh.nb_faces)))
                 S = self.engine.build_S_matrix(
-                    mesh.extract_faces(list(range(i, i+chunk_size))),
+                    mesh.extract_faces(faces_to_extract),
                     result.body.mesh,
                     result.free_surface, result.sea_bottom, result.wavenumber,
                     self.green_function

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ New in next version
 * Add example in cookbook for computing hydrostatics and mass properties
 * Use pytest skipif to skip tests if optional dependecies are not installed
 * Break out impedance from RAO to separate function (see #61`<https://github.com/mancellin/capytaine/issues/61>`_ and (see #63`<https://github.com/mancellin/capytaine/pull/63>`_)
+* Fix bug in free surface elevation computation when the number of faces in the free surface mesh is not a multiple of the chunk size (by default a multiple of 50).
 
 ---------------------------------
 New in version 1.2.1 (2021-04-14)

--- a/pytest/test_free_surface_elevation.py
+++ b/pytest/test_free_surface_elevation.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Tests related to post-processing computation of potential and free surface elevation."""
+
+import pytest
+import numpy as np
+import capytaine as cpt
+
+
+def test_potential():
+    sphere = cpt.Sphere(radius=1.0, ntheta=3, nphi=12, clip_free_surface=True)
+    sphere.add_translation_dof(name="Heave")
+    solver = cpt.BEMSolver()
+    result = solver.solve(cpt.RadiationProblem(body=sphere, omega=1.0), keep_details=True)
+    free_surface = cpt.FreeSurface(x_range=(-100, 100), nx=5, y_range=(-100, 100), ny=5)
+    eta = solver.get_potential_on_mesh(result, free_surface.mesh, chunk_size=3)
+


### PR DESCRIPTION
Fixed the indices of faces to extract when mesh.nb_faces > chunk_size. Now the number of mesh faces need not be a multiple of chunk_size.