### PR TITLE
Heal all meshes

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -62,7 +62,11 @@ class FloatingBody(Abstract3DObject):
         self.dofs = dofs
         self.name = name
 
-        LOG.info(f"New floating body: {self.name}.")
+        if self.mesh.nb_vertices == 0 or self.mesh.nb_faces == 0:
+            LOG.warning(f"New floating body (with empty mesh!): {self.name}.")
+        else:
+            self.mesh.heal_mesh()
+            LOG.info(f"New floating body: {self.name}.")
 
     @staticmethod
     def from_file(filename: str, file_format=None, name=None) -> 'FloatingBody':

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -97,6 +97,11 @@ class CollectionOfMeshes(Abstract3DObject):
             new_mesh.name = name
         return new_mesh
 
+    @inplace_transformation
+    def heal_mesh(self):
+        for mesh in self:
+            mesh.heal_mesh()
+
     ##############
     # Properties #
     ##############

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -98,9 +98,9 @@ class CollectionOfMeshes(Abstract3DObject):
         return new_mesh
 
     @inplace_transformation
-    def heal_mesh(self):
+    def heal_mesh(self, closed_mesh=False):
         for mesh in self:
-            mesh.heal_mesh()
+            mesh.heal_mesh(closed_mesh=closed_mesh)
 
     ##############
     # Properties #

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -724,7 +724,7 @@ class Mesh(Abstract3DObject):
         return remove_degenerated_faces(self, **kwargs)
 
     @inplace_transformation
-    def heal_mesh(self):
+    def heal_mesh(self, closed_mesh=True):
         """Heals the mesh for different tests available.
 
         It applies:
@@ -739,7 +739,8 @@ class Mesh(Abstract3DObject):
         self.remove_degenerated_faces()
         self.merge_duplicates()
         self.heal_triangles()
-        self.heal_normals()
+        if closed_mesh:
+            self.heal_normals()
         return self
 
     #################

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ New in next version
 ---------------------------------
 
 * Add method :code:`FloatingBody.assemble_arbitrary_array` to make an array of bodies with arbitrary layout.
+
+* The mesh are always "healed" when a new :code:`FloatingBody` is initialised
+  (i.e. unused vertices are removed, degenerate triangles are removed, etc.).
+  See for instance `issue #46 <https://github.com/mancellin/capytaine/issues/46>`_.
+
 * Add example in cookbook for computing hydrostatics and mass properties
 * Use pytest skipif to skip tests if optional dependecies are not installed
 * Break out impedance from RAO to separate function (see #61`<https://github.com/mancellin/capytaine/issues/61>`_ and (see #63`<https://github.com/mancellin/capytaine/pull/63>`_)

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -157,7 +157,7 @@ def test_import_cal_file():
         assert problem.depth == np.infty
         assert isinstance(problem.body, FloatingBody)
         assert problem.body.nb_dofs == 6
-        assert problem.body.mesh.nb_vertices == 351
+        assert problem.body.mesh.nb_vertices == 299  # Duplicate vertices are removed during import.
         assert problem.body.mesh.nb_faces == 280
         assert problem.omega in np.linspace(0.1, 2.0, 41)
         if isinstance(problem, DiffractionProblem):


### PR DESCRIPTION
Automatically use the `heal_mesh` method (coming directly from `meshmagick`) at the initialization of all new `FloatingBody`.
For this purpose, `heal_mesh` needed to be extended to collection of meshes and symmetric meshes.

Resolve #46 (I hope)