### PR TITLE
Fixes #85

### DIFF
--- a/capytaine/io/mesh_loaders.py
+++ b/capytaine/io/mesh_loaders.py
@@ -419,7 +419,7 @@ def load_VTU(filename, name=None):
     vtk = import_optional_dependency("vtk")
 
     reader = vtk.vtkXMLUnstructuredGridReader()
-    reader.SetFileName(filename)
+    reader.SetFileName(str(filename))
     reader.Update()
     vtk_mesh = reader.GetOutput()
 
@@ -451,7 +451,7 @@ def load_VTP(filename, name=None):
     vtk = import_optional_dependency("vtk")
 
     reader = vtk.vtkXMLPolyDataReader()
-    reader.SetFileName(filename)
+    reader.SetFileName(str(filename))
     reader.Update()
     vtk_mesh = reader.GetOutput()
 
@@ -483,7 +483,7 @@ def load_VTK(filename, name=None):
     vtk = import_optional_dependency("vtk")
 
     reader = vtk.vtkPolyDataReader()
-    reader.SetFileName(filename)
+    reader.SetFileName(str(filename))
     reader.Update()
     vtk_mesh = reader.GetOutput()
 
@@ -547,7 +547,7 @@ def load_STL(filename, name=None):
     _check_file(filename)
 
     reader = vtk.vtkSTLReader()
-    reader.SetFileName(filename)
+    reader.SetFileName(str(filename))
     reader.Update()
 
     data = reader.GetOutputDataObject(0)
@@ -882,7 +882,7 @@ def load_WRL(filename, name=None):
             raise NotImplementedError('VRML loader only supports VRML 2.0 format (version %s given)' % ver)
 
     importer = vtk.vtkVRMLImporter()
-    importer.SetFileName(filename)
+    importer.SetFileName(str(filename))
     importer.Update()
 
     actors = importer.GetRenderer().GetActors()

--- a/capytaine/io/mesh_writers.py
+++ b/capytaine/io/mesh_writers.py
@@ -242,7 +242,7 @@ def write_VTU(filename, vertices, faces):
 
     writer = vtk.vtkXMLUnstructuredGridWriter()
     writer.SetDataModeToAscii()
-    writer.SetFileName(filename)
+    writer.SetFileName(str(filename))
 
     unstructured_grid = _build_vtkUnstructuredGrid(vertices, faces)
     writer.SetInputData(unstructured_grid)
@@ -269,7 +269,7 @@ def write_VTP(filename, vertices, faces):
 
     writer = vtk.vtkXMLPolyDataWriter()
     writer.SetDataModeToAscii()
-    writer.SetFileName(filename)
+    writer.SetFileName(str(filename))
 
     polydata = _build_vtkPolyData(vertices, faces)
     writer.SetInputData(polydata)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ New in next version
 * Use pytest skipif to skip tests if optional dependecies are not installed
 * Break out impedance from RAO to separate function (see #61`<https://github.com/mancellin/capytaine/issues/61>`_ and (see #63`<https://github.com/mancellin/capytaine/pull/63>`_)
 * Fix bug in free surface elevation computation when the number of faces in the free surface mesh is not a multiple of the chunk size (by default a multiple of 50).
+* Fix bug in some of the mesh readers/writers when using PosixPath paths. 
 
 ---------------------------------
 New in version 1.2.1 (2021-04-14)


### PR DESCRIPTION
The problem was with VTK. The `setFileName` function cannot handle PosixPath inputs. This affected 5 readers and 2 writers. The solution here is to replace all instances of: 
`SetFileName(filename)`
with
`SetFileName(str(filename))`