### PR TITLE
prevent animation test from running without ipython

### DIFF
--- a/pytest/test_ui_vtk.py
+++ b/pytest/test_ui_vtk.py
@@ -9,8 +9,13 @@ try:
 except ImportError:
     vtk = None
 
-@pytest.mark.skipif(vtk is None,
-                    reason='vtk is not installed')
+try:
+    import IPython
+except ImportError:
+    IPython = None
+
+@pytest.mark.skipif(vtk is None or IPython is None,
+                    reason='vtk and/or Ipython are not installed')
 def test_animation_of_dofs():
     body = cpt.Sphere()
     body.add_translation_dof(name="Heave")


### PR DESCRIPTION
[`test_animation_of_dofs`](https://github.com/mancellin/capytaine/blob/de208c89ddbe5592253128166c32436cfcd8c68a/pytest/test_ui_vtk.py) will attempt to run and then will fail if `IPython` is not installed. This very minor change checks if both `IPython` and `vtk` are installed before running this test.

