### PR TITLE
Easier developer install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(SOFILE): $(F90FILES)
 update_fortran: $(SOFILE)
 
 develop: $(SOFILE)
-	pip install -e .
+	pip install -e .[develop]
 
 test: develop
 	python -m pytest

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -11,7 +11,7 @@ It is recommended to use a `conda environment`_.
 
 Ensure that Numpy is installed in your enviroment::
 
-    conda install numpy
+    conda install numpy pip
 
 You'll also need a Fortran compiler:
 
@@ -42,24 +42,14 @@ Then, download the source code from Github web interface or using ``git`` with::
 
     git clone https://github.com/mancellin/capytaine
 
-In the main directory of Capytaine (where ``setup.py`` is located), run the following command to compile the Fortran code::
+To compile the code, install all optional dependencies, and put it in your path::
 
-    python setup.py build_ext --inplace
+    make develop
 
-Re-run this command later to recompile the code if you change one of the Fortran files.
+If you need to recompile::
 
-Add the current directory to the Python path with the following command::
-
-    pip install -e .
-
-(This last two commands are included into the ``Makefile`` of the main directory.
-They can be run by ``make develop``.
-The command ``make clean`` deletes the binaries.)
-
-You will also likely want to install Capytaine's optional dependencies::
-
-	conda install matplotlib vtk pytest quadpy hypothesis ipython
-	pip install pygmsh
+    make clean
+    make develop
 
 For instructions about how to help with the development of Capytaine, see the `contributing guide`_.
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,20 @@ if __name__ == "__main__":
               'pandas',
               'xarray',
           ],
+          extras_require={
+            'develop': [
+              'pytest',
+              'hypothesis',
+              'ipython',
+              'matplotlib',
+              'vtk',
+              'meshio',
+              'pygmsh',
+              'gmsh',
+              'quadpy<=0.14.11',
+              'bemio @ git+https://github.com/michaelcdevin/bemio.git@master-python3#egg=bemio',
+            ]
+          },
           entry_points={
               'console_scripts': [
                   'capytaine=capytaine.ui.cli:main',


### PR DESCRIPTION
It appears you can list optional dependencies in `setup.py` under custom headings within the `extras_require` field. This seems like a handy way to list the relatively large number of optional dependencies now in `capytaine`.

This PR implements this optional dependency approach and uses the `develop` flag to invoke these. This will eliminate/reduce the need for folks to hunt these down sequentially and install them.