### PR TITLE
fix example bug: plot_influence_matrix

### DIFF
--- a/docs/user_manual/examples/plot_influence_matrix.py
+++ b/docs/user_manual/examples/plot_influence_matrix.py
@@ -22,7 +22,7 @@ S, K = engine.build_matrices(
 
 # Plot the absolute value of the matrix S
 import matplotlib.pyplot as plt
-plt.imshow(abs(S))
+plt.imshow(abs(S.full_matrix()))
 plt.colorbar()
 plt.title("$|S|$")
 plt.tight_layout()


### PR DESCRIPTION
I don't fully understand why, but it looks like this stopped working due to d7de51da2a60d0b315258deb2152d9c561c6febb