### PR TITLE
Fix various typos

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -76,7 +76,7 @@ class FloatingBody(Abstract3DObject):
 
         import meshio
         if not isinstance(mesh, meshio._mesh.Mesh):
-            raise TypeError('mesh must be of type meshio._mesh.Mesh, recevied {:}'.format(type(mesh)))
+            raise TypeError('mesh must be of type meshio._mesh.Mesh, received {:}'.format(type(mesh)))
 
         if name is None:
             date_str = datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -8,7 +8,7 @@ MODULE GREEN_WAVE
 
   IMPLICIT NONE
 
-  ! Dependancies between the functions of this module:
+  ! Dependencies between the functions of this module:
   ! (from top to bottom: "is called by")
   !
   !            LAGRANGE_POLYNOMIAL_INTERPOLATION

--- a/capytaine/green_functions/Delhommeau_f90/Initialize_Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Initialize_Green_wave.f90
@@ -70,7 +70,7 @@ CONTAINS
 
   SUBROUTINE INITIALIZE_TABULATED_INTEGRALS(NB_POINTS_X, NB_POINTS_Z, NB_INTEGRATION_POINTS, X, Z, TABULATION)
     ! Compute the tabulated integrals for the wave part of the Green function.
-    ! These tables are independant of the mesh and of the frequency.
+    ! These tables are independent of the mesh and of the frequency.
     ! They are only initialised once at the beginning of the program.
 
     ! References:

--- a/capytaine/green_functions/Delhommeau_f90/old_Prony_decomposition.f90
+++ b/capytaine/green_functions/Delhommeau_f90/old_Prony_decomposition.f90
@@ -589,7 +589,7 @@ CONTAINS
       IF(HH) 42,42,29
    29 A1=A1/HH
       B1=B1/HH
-      C1=C1/HH ! Has C1 been intialized?
+      C1=C1/HH ! Has C1 been initialized?
       H=A1*C1-B1*B1
       IF(H) 30,42,30
    30 A=A/HH

--- a/capytaine/io/mesh_loaders.py
+++ b/capytaine/io/mesh_loaders.py
@@ -30,7 +30,7 @@ def load_mesh(filename, file_format=None, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
     file_format: str, optional
         format of the mesh defined in the extension_dict dictionary
     name: str, optional
@@ -61,7 +61,7 @@ def load_RAD(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -113,7 +113,7 @@ def load_HST(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -187,13 +187,13 @@ def load_DAT(filename, name=None):
 def load_INP(filename, name=None):
     """Loads DIODORE (PRINCIPIA (c)) configuration file format.
 
-    It parses the .INP file and extract meshes defined in subsequent .DAT files using the different informations
+    It parses the .INP file and extracts meshes defined in subsequent .DAT files using the different information
     contained in the .INP file.
 
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -210,7 +210,7 @@ def load_INP(filename, name=None):
     with open(filename, 'r') as f:
         text = f.read()
 
-    # Retrieving frames into a dictionnary frames
+    # Retrieving frames into a dictionary frames
     pattern_frame_str = r'^\s*\*FRAME,NAME=(.+)[\r\n]+(.*)'
     pattern_frame = re.compile(pattern_frame_str, re.MULTILINE)
 
@@ -360,7 +360,7 @@ def load_TEC(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -402,7 +402,7 @@ def load_VTU(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -435,7 +435,7 @@ def load_VTP(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -467,7 +467,7 @@ def load_VTK(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -529,7 +529,7 @@ def load_STL(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -578,7 +578,7 @@ def load_NAT(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -643,7 +643,7 @@ def load_GDF(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -700,7 +700,7 @@ def load_MAR(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -757,7 +757,7 @@ def load_MSH(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -806,7 +806,7 @@ def load_MED(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -868,7 +868,7 @@ def load_WRL(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------
@@ -905,7 +905,7 @@ def load_NEM(filename, name=None):
     Parameters
     ----------
     filename: str
-        name of the meh file on disk
+        name of the mesh file on disk
 
     Returns
     -------

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -237,7 +237,7 @@ def assemble_dataset(results,
                      attrs=None) -> xr.Dataset:
     """Transform a list of :class:`LinearPotentialFlowResult` into a :class:`xarray.Dataset`.
 
-    .. todo:: The :code:`mesh` option to store informations on the mesh could be improved.
+    .. todo:: The :code:`mesh` option to store information on the mesh could be improved.
               It could store the full mesh in the dataset to ensure the reproducibility of
               the results.
 
@@ -246,9 +246,9 @@ def assemble_dataset(results,
     results: list of LinearPotentialFlowResult
         The results that will be read.
     wavenumber: bool, optional
-        If True, the coordinate 'wavenumber' will be added to the ouput dataset.
+        If True, the coordinate 'wavenumber' will be added to the output dataset.
     wavelength: bool, optional
-        If True, the coordinate 'wavelength' will be added to the ouput dataset.
+        If True, the coordinate 'wavelength' will be added to the output dataset.
     mesh: bool, optional
         If True, store some infos on the mesh in the output dataset.
     hydrostatics: bool, optional
@@ -363,7 +363,7 @@ def assemble_dataset(results,
                 dataset.coords['quadrature_method'] = ('body_name', [quad_methods[name] for name in dataset.coords['body_name'].data])
             else:
                 def the_only(d):
-                    """Return the only element of a 1-element dictionnary"""
+                    """Return the only element of a 1-element dictionary"""
                     return next(iter(d.values()))
                 dataset.coords['nb_faces'] = the_only(nb_faces)
                 dataset.coords['quadrature_method'] = the_only(quad_methods)

--- a/capytaine/matrices/block_toeplitz.py
+++ b/capytaine/matrices/block_toeplitz.py
@@ -63,7 +63,7 @@ class BlockToeplitzMatrix(BlockMatrix):
 
     def _block_indices_of(self, k: int) -> Set[Tuple[int, int]]:
         """The block indices at which the stored block k can be found in the full matrix of size n.
-        Will be overriden by subclasses."""
+        Will be overridden by subclasses."""
         n = self.nb_blocks[0]
 
         if k < n:

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -606,7 +606,7 @@ class Mesh(Abstract3DObject):
 
     @inplace_transformation
     def triangulate_quadrangles(self) -> 'Mesh':
-        """Triangulates every quadrangles of the mesh by simple spliting.
+        """Triangulates every quadrangles of the mesh by simple splitting.
         Each quadrangle gives two triangles.
 
         Note

--- a/capytaine/meshes/quality.py
+++ b/capytaine/meshes/quality.py
@@ -251,7 +251,7 @@ def heal_normals(mesh):
 
         tol = 1e-9
         if np.fabs(hs[0]) > tol or np.fabs(hs[1]) > tol:
-            LOG.warning("\t--> the mesh does not seem watertight althought marked as closed...")
+            LOG.warning("\t--> the mesh does not seem watertight although marked as closed...")
 
         if hs[2] < 0:
             flipped = True

--- a/capytaine/tools/prony_decomposition.py
+++ b/capytaine/tools/prony_decomposition.py
@@ -85,7 +85,7 @@ def error_exponential_decomposition(X, F, a, lamda):
     Returns
     -------
     error: float
-        mean square error of the decompostion
+        mean square error of the decomposition
     """
     a = np.asarray(a)[:, np.newaxis]
     lamda = np.asarray(lamda)[:, np.newaxis]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ Major changes
   ring. By default, only reflection symmetry is used. (:pull:`91`)
   The use of symmetries can be controlled with :code:`translation_symmetry` and
   :code:`reflection_symmetry` optional keyword arguments.
-  The :code:`clever` keywork argument is deprecated for :code:`HorizontalCylinder`
+  The :code:`clever` keyword argument is deprecated for :code:`HorizontalCylinder`
   and should be replaced by the new more explicit keyword arguments above.
 
 New features
@@ -40,7 +40,7 @@ Bug fixes
 
 * Fix bug in free surface elevation computation when the number of faces in the free surface mesh is not a multiple of the chunk size, that is by default a multiple of 50 (:pull:`82`).
 
-* The function :code:`assemble_dataset` did not support well the problems without a free surface. In the new version, such problems are explicitely ignored and a warning message is displayed. (:issue:`88` and :pull:`89`).
+* The function :code:`assemble_dataset` did not support well the problems without a free surface. In the new version, such problems are explicitly ignored and a warning message is displayed. (:issue:`88` and :pull:`89`).
 
 * Fix bug in some of the mesh readers/writers when using pathlib path objects (:pull:`87`).
 
@@ -51,7 +51,7 @@ Internal and development
 
 * Easier installation of optional dependencies via :code:`pip install -e .[extra]` and :code:`pip install -e .[develop]` (:pull:`96`).
 
-* Use pytest skipif to skip tests if optional dependecies are not installed (:pull:`68`).
+* Use pytest skipif to skip tests if optional dependencies are not installed (:pull:`68`).
 
 ---------------------------------
 New in version 1.2.1 (2021-04-14)
@@ -91,11 +91,11 @@ New in version 1.2 (2020-04-24)
 
 * Improvement of caching to limit RAM usage for large problems.
 
-* Make optional the dependancy to graphical packages (`matplotlib` and `vtk`).
+* Make optional the dependency to graphical packages (`matplotlib` and `vtk`).
   They were causing issues to some users.
 
 * :code:`problems_and_results.py` has been rewritten to be slightly more readable and
-  remove the dependancy to `attrs`.
+  remove the dependency to `attrs`.
 
 -------------------------------
 New in version 1.1 (2019-09-24)
@@ -159,7 +159,7 @@ Major changes
 * Most of the modules have been reorganized in several packages. See the
   :doc:`developer_manual/overview` for some details.
 
-* Test compability of the code with Python 3.7 and numpy 1.16.
+* Test compatibility of the code with Python 3.7 and numpy 1.16.
 
 * Remove a couple of unmaintained or unfinished submodules.
 
@@ -302,7 +302,7 @@ Major changes
   The parallelization in :code:`solve_all` has been removed.
 
 * Integration of a refactored subset of Meshmagick into Capytaine as the :code:`mesh` submodule.
-  Meshmagick is not a dependancy any more.
+  Meshmagick is not a dependency any more.
 
 * Reorganization of the submodules:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,7 +189,7 @@ todo_include_todos = True
 
 math_number_all = True
 
-# Options for napolean
+# Options for napoleon
 
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -13,7 +13,7 @@ Capytaine is based on
 .. _`Python scientific ecosystem`: https://scipy.org/
 
 For users, it can be seen as a Python 3.6 (or higher) interface to Nemoh.
-Since most of the code has been rewritten, it can be used by developpers as a
+Since most of the code has been rewritten, it can be used by developers as a
 more concise and better documented version of Nemoh.
 
 Below some features of the latest version (version |version|) of Capytaine are listed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ License
     </a>
     </div>
 
-Capytaine has been developped by `Matthieu Ancellin`_ (University College Dublin) and is distributed under the terms of the GNU General Public License (GPL) v3.0. See the ``LICENSE`` file in the `code repository`_.
+Capytaine has been developed by `Matthieu Ancellin`_ (University College Dublin) and is distributed under the terms of the GNU General Public License (GPL) v3.0. See the ``LICENSE`` file in the `code repository`_.
 
 .. _`code repository`: https://github.com/mancellin/capytaine
 .. _`Matthieu Ancellin`: http://ancell.in

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -166,7 +166,7 @@ The second part reads
     G_1(\xi, x) = - \frac{1}{\|x - s(\xi)\|} 
     :label: green_function_inf_depth_1
 
-where :math:`s(\xi_1, \xi_2, \xi_3) = (\xi_1, \xi_2, -\xi_3)` is the reflection of :math:`\xi` accross the free surface.
+where :math:`s(\xi_1, \xi_2, \xi_3) = (\xi_1, \xi_2, -\xi_3)` is the reflection of :math:`\xi` across the free surface.
 
 Finally, this last part is complex-valued and it is introduced to satisfy the boundary conditions :eq:`bc_fs`.
 It depends on the water depth :math:`h` and the wave frequency :math:`\omega` (through the wave number :math:`k`).

--- a/docs/user_manual/examples/Nemoh.cal
+++ b/docs/user_manual/examples/Nemoh.cal
@@ -22,7 +22,7 @@ Cylinder.dat            ! Name of mesh file
 2  1  0  0  0  0  -7.5  ! Moment force in x direction about CdG !! This line is ignored !!
 2  0  1  0  0  0  -7.5  ! Moment force in y direction about CdG !! This line is ignored !!
 2  0  0  1  0  0  -7.5  ! Moment force in z direction about CdG !! This line is ignored !!
-0                       ! Number of lines of additional information !! All the additional informations are ignored !!
+0                       ! Number of lines of additional information !! All the additional information is ignored !!
 --- Load cases to be solved ---
 2  0.1  2.0             ! Number of wave frequencies, Min, and Max (rad/s)
 1  0.0  0.0             ! Number of wave directions, Min and Max (degrees)

--- a/docs/user_manual/installation.rst
+++ b/docs/user_manual/installation.rst
@@ -33,7 +33,7 @@ With Pip
 --------
 
 The package is available on PyPI, although only as a source distribution.
-That means that you'll nead a Fortran compiler [#]_ in order to install the package.
+That means that you'll need a Fortran compiler [#]_ in order to install the package.
 If you do, you can install Capytaine as::
 
     pip install numpy
@@ -43,7 +43,7 @@ If you want, you can then install the optional dependencies::
 
     pip install matplotlib vtk
 
-If you can't install a compiler, it is recommanded to use Conda instead.
+If you can't install a compiler, it is recommended to use Conda instead.
 
 .. [#] For example, on Ubuntu or Debian: :code:`sudo apt install gfortran`.
 

--- a/docs/user_manual/mesh.rst
+++ b/docs/user_manual/mesh.rst
@@ -58,28 +58,28 @@ The formats currently supported by Meshmagick in reading are the following (from
 |   .med    | SALOME [#f8]_   | med, salome          |
 +-----------+-----------------+----------------------+
 
-.. [#f1] NEMOH is an open source BEM Software for seakeeping developped at
+.. [#f1] NEMOH is an open source BEM Software for seakeeping developed at
          Ecole Centrale de Nantes (LHEEA)
-.. [#f2] WAMIT is a BEM Software for seakeeping developped by WAMIT, Inc.
-.. [#f3] DIODORE is a BEM Software for seakeeping developped by PRINCIPIA
-.. [#f4] HYDROSTAR is a BEM Software for seakeeping developped by
+.. [#f2] WAMIT is a BEM Software for seakeeping developed by WAMIT, Inc.
+.. [#f3] DIODORE is a BEM Software for seakeeping developed by PRINCIPIA
+.. [#f4] HYDROSTAR is a BEM Software for seakeeping developed by
          BUREAU VERITAS
-.. [#f5] GMSH is an open source meshing software developped by C. Geuzaine
+.. [#f5] GMSH is an open source meshing software developed by C. Geuzaine
          and J.-F. Remacle. Version 4 of the file format is not supported at the
          moment.
-.. [#f6] PARAVIEW is an open source visualization software developped by
+.. [#f6] PARAVIEW is an open source visualization software developed by
          Kitware
-.. [#f7] TECPLOT is a visualization software developped by Tecplot
+.. [#f7] TECPLOT is a visualization software developed by Tecplot
 .. [#f8] SALOME-MECA is an open source software for computational mechanics
-         developped by EDF-R&D
+         developed by EDF-R&D
 
 
 Importing a mesh with Meshio
 ----------------------------
 
 Mesh can also be imported using the `meshio <https://pypi.org/project/meshio/>`_
-library. Unlike the Meshmagick mesh readers mentionned above, this library is
-not packaged with Capytaine and need to be installed independantly::
+library. Unlike the Meshmagick mesh readers mentioned above, this library is
+not packaged with Capytaine and need to be installed independently::
 
     pip install meshio
 
@@ -93,7 +93,7 @@ method::
 This features allows to use `pygmsh <https://pypi.org/project/pygmsh/>`_ to
 generate the mesh, since this library returns mesh in the same format as meshio.
 Below is an example of a mesh generation with `pygmsh` (which also needs to be
-installed independantly)::
+installed independently)::
 
     import pygmsh
     offset = 1e-2

--- a/docs/user_manual/outputs.rst
+++ b/docs/user_manual/outputs.rst
@@ -16,13 +16,13 @@ If you gave a test matrix to the :code:`BEMSolver.fill_dataset` method, the
 output will directly be an xarray dataset.
 
 Both :code:`assemble_dataset` and :code:`fill_dataset` accept some optional keyword
-arguments to store more informations in the dataset:
+arguments to store more information in the dataset:
 
 - :code:`wavenumber` (default: :code:`False`): add the wavenumber of the
   incoming waves in the dataset.
 - :code:`wavelength` (default: :code:`False`): add the wavelength of the
   incoming waves in the dataset.
-- :code:`mesh` (default: :code:`False`): add some informations about the mesh in
+- :code:`mesh` (default: :code:`False`): add some information about the mesh in
   the dataset (number of faces, quadrature method).
 - :code:`hydrostatics` (default: :code:`True`): if hydrostatics data are
   available in the :code:`FloatingBody`, they are added to the dataset. 
@@ -113,7 +113,7 @@ They can be stored in xarray either as NetCDF string objects, which can be writt
 The issue is that the xarray library sometimes changes from one to the other without warnings.
 It leads to the error :code:`ValueError: unsupported dtype for netCDF4 variable: object` when trying to export a dataset.
 
-This can be fixed by explicitely converting the strings to the right format when exporting the dataset::
+This can be fixed by explicitly converting the strings to the right format when exporting the dataset::
 
     dataset.to_netcdf("dataset.nc",
                       encoding={'radiating_dof': {'dtype': 'U'},

--- a/docs/user_manual/problem_setup.rst
+++ b/docs/user_manual/problem_setup.rst
@@ -68,7 +68,7 @@ The table below gives their definitions and their default values.
 .. [#] A wave direction of :math:`0` rad corresponds to a wave propagating along
        the :math:`x`-axis from :math:`x = -\infty` to :math:`x= + \infty`.
 
-The wave height is implicitely assumed to be :math:`1` m.
+The wave height is implicitly assumed to be :math:`1` m.
 Since all computations are linear, any wave height or motion amplitude can be retrieved by multiplying the result by the desired value.
 
 The following attributes are automatically computed for a given problem:

--- a/pytest/Nemoh_verification_cases/Nemoh.m
+++ b/pytest/Nemoh_verification_cases/Nemoh.m
@@ -11,7 +11,7 @@
 % Outputs :
 % - A  : Matrix (6xnBodies)x(6xnBodies)xlength(w) of added mass coefficients
 % - B  : Matrix (6xnBodies)x(6xnBodies)xlength(w) of radiation damping coefficients
-% - Fe : Matrix (6xnBodies)xlength(w) of exciation forces (complex
+% - Fe : Matrix (6xnBodies)xlength(w) of excitation forces (complex
 % values)
 %
 % Copyright Ecole Centrale de Nantes 2014

--- a/pytest/test_io_meshes.py
+++ b/pytest/test_io_meshes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-"""Tests for the mesh import of mesh from external librairies"""
+"""Tests for the mesh import of mesh from external libraries"""
 
 import pytest
 

--- a/pytest/test_matrices.py
+++ b/pytest/test_matrices.py
@@ -301,7 +301,7 @@ def test_block_symmetric_toeplitz_matrices():
 
 
 def test_block_circulant_matrix():
-    # 5x5 block symmetric circulant matrix reprensentation of the identity matrix
+    # 5x5 block symmetric circulant matrix representation of the identity matrix
     A = BlockCirculantMatrix([
         [np.eye(2, 2), np.zeros((2, 2)), np.zeros((2, 2))]
     ])
@@ -333,7 +333,7 @@ def test_block_circulant_matrix():
 
 
 def test_even_block_symmetric_circulant_matrix():
-    # 5x5 block symmetric circulant matrix reprensentation of the identity matrix
+    # 5x5 block symmetric circulant matrix representation of the identity matrix
     A = EvenBlockSymmetricCirculantMatrix([
         [np.eye(2, 2), np.zeros((2, 2)), np.zeros((2, 2))]
     ])


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,informations,inout,ist,ment,noe,periode,sur`