### PR TITLE
Fix logging order

### DIFF
--- a/capytaine/post_pro/rao.py
+++ b/capytaine/post_pro/rao.py
@@ -37,12 +37,13 @@ def rao(dataset, wave_direction=0.0, dissipation=None, stiffness=None):
     xarray DataArray
         The RAO as an array depending of omega and the degree of freedom.
     """
-    LOG.info("Compute RAO.")
 
     # ASSEMBLE MATRICES
-    omega = dataset.coords['omega']  # Range of frequencies in the dataset
-
     A = impedance(dataset, dissipation, stiffness)
+
+    LOG.info("Compute RAO.")
+
+    omega = dataset.coords['omega']  # Range of frequencies in the dataset
 
     if 'excitation_force' not in dataset:
         dataset['excitation_force'] = dataset['Froude_Krylov_force'] + dataset['diffraction_force']


### PR DESCRIPTION
Just make the log displays "Compute impedance" before "Compute RAO".