### PR TITLE
Improve error messages

### DIFF
--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -113,6 +113,7 @@ CONTAINS
 
     IF ((R1 < 1e-5) .OR. (wavenumber == 0)) THEN
       PRINT*, "Error: Impossible to compute the wave part of the Green function (division by zero)."
+      PRINT*, "This is often due to mesh panels on the free surface (z=0)."
       ERROR STOP
     ENDIF
 

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -195,7 +195,7 @@ class Delhommeau(AbstractGreenFunction):
             mesh1 is mesh2
         )
 
-        if np.isnan(np.sum(S)) or np.isnan(np.sum(K)):
+        if np.any(np.isnan(S)) or np.any(np.isnan(K)):
             raise RuntimeError("Green function returned a NaN in the interaction matrix.\n"
                     "It could be due to overlapping panels.")
 

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -182,7 +182,7 @@ class Delhommeau(AbstractGreenFunction):
                 coeffs = np.array((1.0, 1.0, 1.0))
 
         # Main call to Fortran code
-        return self.fortran_core.matrices.build_matrices(
+        S, K = self.fortran_core.matrices.build_matrices(
             mesh1.faces_centers, mesh1.faces_normals,
             mesh2.vertices,      mesh2.faces + 1,
             mesh2.faces_centers, mesh2.faces_normals,
@@ -194,6 +194,12 @@ class Delhommeau(AbstractGreenFunction):
             lamda_exp, a_exp,
             mesh1 is mesh2
         )
+
+        if np.isnan(np.sum(S)) or np.isnan(np.sum(K)):
+            raise RuntimeError("Green function returned a NaN in the interaction matrix.\n"
+                    "It could be due to overlapping panels.")
+
+        return S, K
 
 ################################
 

--- a/capytaine/matrices/linear_solvers.py
+++ b/capytaine/matrices/linear_solvers.py
@@ -93,8 +93,10 @@ def solve_gmres(A, b):
     else:
         x, info = ssl.gmres(A, b, atol=1e-6)
 
-    if info != 0:
-        LOG.warning(f"No convergence of the GMRES. Error code: {info}")
+    if info > 0:
+        raise RuntimeError(f"No convergence of the GMRES after {info} iterations.\n"
+                            "This can be due to overlapping panels or irregular frequencies.\n"
+                            "In the latter case, using a direct solver can help (https://github.com/mancellin/capytaine/issues/30).")
 
     return x
 


### PR DESCRIPTION
Follow-up on #50

- [x] Division by zero
- [x] No-convergence of GMRES
- [x] Direct solver might fail without warning when there are overlapping panels