### PR TITLE
Add sanity checks for the keys of test matrices.

### DIFF
--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -50,6 +50,11 @@ def problems_from_dataset(dataset: xr.Dataset,
     Returns
     -------
     list of LinearPotentialFlowProblem
+
+    Raises
+    ------
+    ValueError
+        if required fields are missing in the dataset
     """
     if isinstance(bodies, FloatingBody):
         bodies = [bodies]

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -54,15 +54,21 @@ def problems_from_dataset(dataset: xr.Dataset,
     if isinstance(bodies, FloatingBody):
         bodies = [bodies]
 
+    # SANITY CHECKS
     assert len(list(set(body.name for body in bodies))) == len(bodies), \
         "All bodies should have different names."
 
     # Warn user in case of key with unrecognized name (e.g. mispells)
-    keys_in_dataset = set(dataset.keys()) & set(dataset.coords.keys())
+    keys_in_dataset = set(dataset.keys()) | set(dataset.coords.keys())
     accepted_keys = {'wave_direction', 'radiating_dof', 'body_name', 'omega', 'water_depth', 'rho', 'g'}
     unrecognized_keys = keys_in_dataset.difference(accepted_keys)
     if len(unrecognized_keys) > 0:
         LOG.warning(f"Unrecognized key(s) in dataset: {unrecognized_keys}")
+
+    if ("radiating_dof" not in keys_in_dataset) and ("wave_direction" not in keys_in_dataset):
+        raise ValueError("Neither 'radiating_dof' nor 'wave_direction' has been provided in the dataset. "
+                "No linear potential flow problem can be inferred.")
+    # END SANITY CHECKS
 
     dataset = _unsqueeze_dimensions(dataset)
 

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -57,6 +57,13 @@ def problems_from_dataset(dataset: xr.Dataset,
     assert len(list(set(body.name for body in bodies))) == len(bodies), \
         "All bodies should have different names."
 
+    # Warn user in case of key with unrecognized name (e.g. mispells)
+    keys_in_dataset = set(dataset.keys()) && set(dataset.coords.keys())
+    accepted_keys = {'wave_direction', 'radiating_dof', 'body_name', 'omega', 'water_depth', 'rho', 'g'}
+    unrecognized_keys = keys_in_dataset.difference(accepted_keys)
+    if len(unrecognized_keys) > 0:
+        LOG.warning(f"Unrecognized key(s) in dataset: {unrecognized_keys}")
+
     dataset = _unsqueeze_dimensions(dataset)
 
     omega_range = dataset['omega'].data if 'omega' in dataset else [_default_parameters['omega']]

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -58,7 +58,7 @@ def problems_from_dataset(dataset: xr.Dataset,
         "All bodies should have different names."
 
     # Warn user in case of key with unrecognized name (e.g. mispells)
-    keys_in_dataset = set(dataset.keys()) && set(dataset.coords.keys())
+    keys_in_dataset = set(dataset.keys()) & set(dataset.coords.keys())
     accepted_keys = {'wave_direction', 'radiating_dof', 'body_name', 'omega', 'water_depth', 'rho', 'g'}
     unrecognized_keys = keys_in_dataset.difference(accepted_keys)
     if len(unrecognized_keys) > 0:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,8 +25,10 @@ Changelog
 
 * Raises an error when a body with an empty mesh is given to :code:`LinearPotentialFlowProblem` (:issue:`128`).
 
-* The functions :code:`problems_from_dataset` and :code:`fill_dataset` accept a body alone as input.
-  That is, one can use :code:`fill_dataset(test_matrix, body)` and not only :code:`fill_dataset(test_matrix, [body])` (pull:`144`).
+* The functions :func:`~capytaine.io.xarray.problems_from_dataset` and :meth:`~capytaine.bem.solver.BEMSolver.fill_dataset` accept a body alone as input.
+  That is, one can use :code:`fill_dataset(test_matrix, body)` and not only :code:`fill_dataset(test_matrix, [body])` (:pull:`144`).
+  These functions now warn users when a key is unknown.
+  An error is raised if neither :code:`radiating_dof` (for radiation problems) nor :code:`wave_direction` (for diffraction problems) is provided (:pull:`155`).
 
 * Add method to compute some of the hydrostatic parameters such as volume, buoyancy center, wet surface area, hydrostatic stiffness, inertia matrix etc.
   :code:`compute_hydrostatics` method is created to return all hydrostatic parameters similar to :code:`meshmagick.hydrostatics.compute_hydrostatics` (:pull:`106`).

--- a/pytest/test_io.py
+++ b/pytest/test_io.py
@@ -5,7 +5,16 @@ import capytaine as cpt
 import pytest
 import os
 
-from capytaine.io.xarray import separate_complex_values, merge_complex_values
+from capytaine.io.xarray import problems_from_dataset, separate_complex_values, merge_complex_values
+
+
+def test_incomplete_test_matrix():
+    body = cpt.Sphere()
+    test_matrix = xr.Dataset(coords={
+        "omega": np.linspace(0, 1, 2),
+        })
+    with pytest.raises(ValueError):
+        problems_from_dataset(test_matrix, body)
 
 
 def test_remove_complex_values():


### PR DESCRIPTION
Took me way too long to figure out the issue with
```python
test_matrix = xr.Dataset(coords={
    "omega": np.linspace(0.03, 9.24, 40),
    "radiating_dofs": list(body.dofs),
    })
```