### PR TITLE
Improve asymptotic behavior for high frequencies

### DIFF
--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -117,9 +117,9 @@ CONTAINS
       ERROR STOP
     ENDIF
 
-    !=====================================================================================
-    ! Evaluate the elementary integrals PDnX and PDnZ depending on dimless_Z and dimless_r
-    !=====================================================================================
+    !=======================================================================
+    ! Evaluate the elementary integrals depending on dimless_Z and dimless_r
+    !=======================================================================
     IF ((dimless_Z < MAXVAL(tabulated_Z_range)) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
         ! Within the range of tabulated data
 

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -120,10 +120,8 @@ CONTAINS
     !=====================================================================================
     ! Evaluate the elementary integrals PDnX and PDnZ depending on dimless_Z and dimless_r
     !=====================================================================================
-    IF (((MINVAL(tabulated_Z_range) < dimless_Z) .AND. (dimless_Z < MAXVAL(tabulated_Z_range))) .AND. &
-        ((MINVAL(tabulated_r_range) <= dimless_r) .AND. (dimless_r < MAXVAL(tabulated_r_range)))) THEN
+    IF ((dimless_Z < MAXVAL(tabulated_Z_range)) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
         ! Within the range of tabulated data
-        ! Note that MINVAL(tabulated_r_range) == 0, so one of the conditions is not actually useful.
 
         ! Get the nearest point in the tabulation
         IF (dimless_r < 1) THEN
@@ -147,8 +145,7 @@ CONTAINS
              tabulated_integrals(KI-1:KI+1, KJ-1:KJ+1, :, :),            &
              D1, D2, Z1, Z2)
 
-      ELSE  ! MAXVAL(tabulated_r_range) < dimless_r
-        ! Asymptotic expression for (horizontally) distant panels
+      ELSE ! Asymptotic expression for distant panels
 
         expz_sqr = EXP(dimless_Z) * SQRT(2*PI/dimless_r)
         cos_kr  = COS(dimless_r - PI/4)

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -117,10 +117,12 @@ CONTAINS
       ERROR STOP
     ENDIF
 
+    ! PRINT*, dimless_r, dimless_Z
     !=======================================================================
     ! Evaluate the elementary integrals depending on dimless_Z and dimless_r
     !=======================================================================
-    IF ((dimless_Z < MAXVAL(tabulated_Z_range)) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
+    IF ((MINVAL(tabulated_Z_range) < dimless_Z) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
+        ! PRINT*, "TABULATED"
         ! Within the range of tabulated data
 
         ! Get the nearest point in the tabulation
@@ -146,6 +148,9 @@ CONTAINS
              D1, D2, Z1, Z2)
 
       ELSE ! Asymptotic expression for distant panels
+        ! PRINT*, "ASYMPTOTIC"
+
+        dimless_r = MAX(dimless_r, 1e-10)  ! Avoid divisions by zero
 
         expz_sqr = EXP(dimless_Z) * SQRT(2*PI/dimless_r)
         cos_kr  = COS(dimless_r - PI/4)

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -120,8 +120,8 @@ CONTAINS
     !=====================================================================================
     ! Evaluate the elementary integrals PDnX and PDnZ depending on dimless_Z and dimless_r
     !=====================================================================================
-    IF ((MINVAL(tabulated_Z_range) < dimless_Z) .AND. (dimless_Z < MAXVAL(tabulated_Z_range))) THEN
-      IF ((MINVAL(tabulated_r_range) <= dimless_r) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
+    IF (((MINVAL(tabulated_Z_range) < dimless_Z) .AND. (dimless_Z < MAXVAL(tabulated_Z_range))) .AND. &
+        ((MINVAL(tabulated_r_range) <= dimless_r) .AND. (dimless_r < MAXVAL(tabulated_r_range)))) THEN
         ! Within the range of tabulated data
         ! Note that MINVAL(tabulated_r_range) == 0, so one of the conditions is not actually useful.
 
@@ -182,11 +182,6 @@ CONTAINS
         ! Limit case r ~ 0 ?
         VS(1:2) = CMPLX(0.0, 0.0, KIND=PRE)
       END IF
-
-    ELSE  ! dimless_Z < MINVAL(tabulated_Z_range) or MAXVAL(tabulated_Z_range) < dimless_Z
-      FS      = CMPLX(dimless_Z/dimless_R1**3, 0.0, KIND=PRE)
-      VS(1:3) = CMPLX(0.0, 0.0, KIND=PRE)
-    ENDIF
 
     RETURN
   END SUBROUTINE COMPUTE_INTEGRALS_WRT_THETA

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -117,12 +117,10 @@ CONTAINS
       ERROR STOP
     ENDIF
 
-    ! PRINT*, dimless_r, dimless_Z
     !=======================================================================
     ! Evaluate the elementary integrals depending on dimless_Z and dimless_r
     !=======================================================================
     IF ((MINVAL(tabulated_Z_range) < dimless_Z) .AND. (dimless_r < MAXVAL(tabulated_r_range))) THEN
-        ! PRINT*, "TABULATED"
         ! Within the range of tabulated data
 
         ! Get the nearest point in the tabulation
@@ -148,8 +146,6 @@ CONTAINS
              D1, D2, Z1, Z2)
 
       ELSE ! Asymptotic expression for distant panels
-        ! PRINT*, "ASYMPTOTIC"
-
         dimless_r = MAX(dimless_r, 1e-10)  ! Avoid divisions by zero
 
         expz_sqr = EXP(dimless_Z) * SQRT(2*PI/dimless_r)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
   dissipation matrix was wrong in previous versions (:issue:`102` and
   :pull:`140`).
 
+* Fix major inaccuracy for deep panels or high frequencies, that is panels deeper than :math:`1.2\lambda` below the free surface where :math:`\lambda` is the wavelength (:issue:`38` and :pull:`156`)
+
 * Correct the function :func:`~capytaine.post_pro.impedance.impedance` to actually return the impedance matrix.
   The former behavior has been renamed as :func:`~capytaine.post_pro.impedance.rao_transfer_function`. (:pull:`142`, :issue:`147`, :pull:`149`).
 

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -93,10 +93,10 @@ def test_tabulations():
 
 
 points = arrays(float, (3,),
-                elements=floats(min_value=-1e5, max_value=1e5, allow_infinity=False, allow_nan=False)
-                ).filter(lambda x: x[2] < -1e-4)
+                elements=floats(min_value=-10, max_value=10, allow_infinity=False, allow_nan=False)
+                ).filter(lambda x: x[2] < -1e-5)
 cores = one_of(just(Delhommeau_f90), just(XieDelhommeau_f90))
-frequencies = floats(min_value=1e-1, max_value=1e1)
+frequencies = floats(min_value=1e-2, max_value=1e2)
 depths = one_of(floats(min_value=10.0, max_value=100.0), just(np.infty))
 
 gravity = 9.8

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -104,15 +104,10 @@ gravity = 9.8
 def wave_part_Green_function(Xi, Xj, omega, depth, core=Delhommeau_f90):
     if depth == np.infty:
         wavenumber = omega**2 / gravity
-    else:
-        wavenumber = newton(lambda x: x*np.tanh(x) - omega**2*depth/gravity, x0=1.0)/depth
-
-    if depth < np.infty:
-        ambda, ar, nexp = core.old_prony_decomposition.lisc(omega**2 * depth/gravity, wavenumber * depth)
-
-    if depth == np.infty:
         return core.green_wave.wave_part_infinite_depth(wavenumber, Xi, Xj, *tabulation[core])
     else:
+        wavenumber = newton(lambda x: x*np.tanh(x) - omega**2*depth/gravity, x0=1.0)/depth
+        ambda, ar, nexp = core.old_prony_decomposition.lisc(omega**2 * depth/gravity, wavenumber * depth)
         return core.green_wave.wave_part_finite_depth(wavenumber, Xi, Xj, depth, *tabulation[core], ambda, ar, 31)
 
 @given(points, points, frequencies, depths, cores)


### PR DESCRIPTION
This PR would fix one of the issues with high frequencies (cf. #20 and #38).

![Wrong_asymptotics](https://user-images.githubusercontent.com/31126826/174035588-1be5b876-cd21-4825-aae0-0b1867fa5cde.png)
(Dashed line is the current master branch. The plain line is the current pull request.)

The wrong asymptotic for high frequencies was caused by the following lines
https://github.com/mancellin/capytaine/blob/416175d102b9eb6f54d9d0f6775634afaddbfad4/capytaine/green_functions/Delhommeau_f90/Green_wave.f90#L186-L189
which were an attempt at transposing [these lines](https://github.com/LHEEA/Nemoh/blob/49393be96bd590e267bfbc16347b665cda0edeb8/Solver/Core/COMPUTE_GREEN_INFD.f90#L331-L336) and [these lines from Nemoh](https://github.com/LHEEA/Nemoh/blob/49393be96bd590e267bfbc16347b665cda0edeb8/Solver/Core/COMPUTE_GREEN_INFD.f90#L361-L366). I might have misunderstood the code from Nemoh, leading to a very different result.
Anyway, this if-else branch is not mentioned in any theoretical documentation and does not seem really justified nor necessary, so I'm just removing it in this PR.

Note that it does not solve all the issues with high frequencies. On the test case of #20, it seems to bring Capytaine close to Nemoh v113, but not to Nemoh v115. The remaining precision improvement will be handled in another PR.