### PR TITLE
Update quadpy integration for quadrature computation

### DIFF
--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -312,39 +312,56 @@ class Mesh(Abstract3DObject):
 
     def compute_quadrature(self, method):
         quadpy = import_optional_dependency("quadpy")
-        transform = quadpy.ncube._helpers.transform
-        get_detJ = quadpy.ncube._helpers.get_detJ
+        transform = quadpy.c2.transform
+        get_detJ = quadpy.cn._helpers.get_detJ
 
         if method is None:
+            # No quadrature (i.e. default first order quadrature)
             if 'quadrature' in self.__internals__:
                 del self.__internals__['quadrature']
                 del self.__internals__['quadrature_method']
             else:
                 pass
 
-        elif isinstance(method, quadpy.quadrilateral._helpers.QuadrilateralScheme):
-            points = np.empty((self.nb_faces, len(method.points), 3))
-            weights = np.empty((self.nb_faces, len(method.points)))
+        elif isinstance(method, quadpy.c2._helpers.C2Scheme):
+            assert method.points.shape[0] == method.dim == 2
+            nb_points = method.points.shape[1]
+            points = np.empty((self.nb_faces, nb_points, 3))
+            weights = np.empty((self.nb_faces, nb_points))
 
             self.heal_triangles()
 
             for i_face in range(self.nb_faces):
-                ref = self.vertices[self.faces[i_face, 0], :]
-                A, B, C, D = self.vertices[self.faces[i_face, :], :] - ref
+                # Define a local frame (Oxyz) such that
+                # * the corner A of the quadrilateral panel is the origin of the local frame
+                # * the edge AB of the quadrilateral panel is along the local x-axis,
+                # * the quadrilateral panel is within the local xy-plane (that is, its normal is along the local z-axis).
+                # Hence, the corners of the panels all have 0 as z-coordinate in the local frame.
+
+                # Coordinates in global frame
+                global_A, global_B, global_C, global_D = self.vertices[self.faces[i_face, :], :]
                 n = self.faces_normals[i_face, :]
 
-                ex = (B-A)/norm(B-A)
-                ez = n/norm(n)
-                ey = np.cross(ex, ez)
+                ex = (global_B-global_A)/norm(global_B-global_A)  # unit vector of the local x-axis
+                ez = n/norm(n)                                    # unit vector of the local z-axis
+                ey = np.cross(ex, ez)                             # unit vector of the local y-axis, such that the basis is orthonormal
+
                 R = np.array([ex, ey, ez])
-                quadrilateral = np.array([[R @ A, R @ D], [R @ B, R @ C]])[:, :, :2]
+                local_A = np.zeros((3,))             # coordinates of A in local frame, should be zero by construction
+                local_B = R @ (global_B - global_A)  # coordinates of B in local frame
+                local_C = R @ (global_C - global_A)  # coordinates of C in local frame
+                local_D = R @ (global_D - global_A)  # coordinates of D in local frame
 
-                quadpoints = transform(method.points.T, quadrilateral)
-                quadpoints = np.concatenate([quadpoints, np.zeros((quadpoints.shape[0], 1))], axis=1)
-                quadpoints = np.array([R.T @ p for p in quadpoints]) + ref
-                points[i_face, :, :] = quadpoints
+                local_quadrilateral = np.array([[local_A, local_D], [local_B, local_C]])[:, :, :-1]
+                # Removing last index in last dimension because not interested in z-coordinate which is 0.
 
-                weights[i_face, :] = method.weights * abs(get_detJ(method.points.T, quadrilateral))
+                local_quadpoints = transform(method.points, local_quadrilateral)
+
+                local_quadpoints_in_3d = np.concatenate([local_quadpoints, np.zeros((nb_points, 1))], axis=1)
+                global_quadpoints = np.array([R.T @ p for p in local_quadpoints_in_3d]) + global_A
+                points[i_face, :, :] = global_quadpoints
+
+                weights[i_face, :] = method.weights * 4 * np.abs(get_detJ(method.points, local_quadrilateral))
 
             self.__internals__['quadrature'] = (points, weights)
             self.__internals__['quadrature_method'] = method

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,8 @@ Changelog
   The :code:`clever` keyword argument is deprecated for :code:`Sphere` and should be replaced by the more explicit keyword arguments :code:`axial_symmetry`.
   Meanwhile, a bug has been fixed with its :code:`geometric_center` (:pull:`150`).
 
+* Support for quadratures from `quadpy <https://pypi.org/project/quadpy/>_` has been updated to support the version 0.16.16 of quadpy (:pull:`164`).
+
 -------------------------------
 New in version 1.3 (2021-10-07)
 -------------------------------

--- a/pytest/test_bem_with_quadratures.py
+++ b/pytest/test_bem_with_quadratures.py
@@ -8,25 +8,34 @@ import capytaine as cpt
 
 try:
     import quadpy
-    from packaging import version
-    quadpy_version = version.parse(quadpy.__version__)
 except ImportError:
     quadpy = None
 
 
-@pytest.mark.skipif(quadpy is None or not quadpy_version < version.parse('0.15'),
-                    reason='quadpy not installed or incorrect version (must be <0.15) ')
-def test_area():
+@pytest.mark.skipif(quadpy is None, reason="quadpy is not installed")
+def test_quadrature_points_are_coplanar():
+    # Check that all quadrature points are within the plane containing the panel
     mesh = cpt.Sphere().mesh
+    for method in [quadpy.c2.schemes['sommariva_05'](), quadpy.c2.schemes["stroud_c2_7_4"]()]:
+        mesh.compute_quadrature(method)
+        for i_face in range(mesh.nb_faces):
+            A, B, C, D = mesh.vertices[mesh.faces[i_face, :], :]
+            for j_quad_point in range(mesh.quadrature_points[0].shape[1]):
+                X = mesh.quadrature_points[0][i_face, j_quad_point, :]
+                assert np.isclose(np.dot(np.cross(B-A, C-A), X-A), 0.0, atol=1e-8)
 
-    for quadrature in [quadpy.quadrilateral.sommariva_05(), quadpy.quadrilateral.stroud_c2_7_2()]:
-        mesh.compute_quadrature(quadrature)
+
+@pytest.mark.skipif(quadpy is None, reason="quadpy is not installed")
+def test_area():
+    # Check that quadrature weights sum to the area of the panel
+    mesh = cpt.Sphere().mesh
+    for method in [quadpy.c2.schemes['sommariva_05'](), quadpy.c2.schemes["stroud_c2_7_4"]()]:
+        mesh.compute_quadrature(method)
         for i_face in range(mesh.nb_faces):
             assert np.isclose(np.sum(mesh.quadrature_points[1][i_face, :]), mesh.faces_areas[i_face], rtol=1e-2)
 
 
-@pytest.mark.skipif(quadpy is None or not quadpy_version < version.parse('0.15'),
-                    reason='quadpy not installed or incorrect version (must be <0.15) ')
+@pytest.mark.skipif(quadpy is None, reason="quadpy is not installed")
 def test_resolution():
     cylinder = cpt.HorizontalCylinder(
         length=5.0, radius=1.0,
@@ -43,10 +52,10 @@ def test_resolution():
 
     solver = cpt.BEMSolver()
 
-    cylinder.mesh.compute_quadrature(quadpy.quadrilateral.sommariva_01())
+    cylinder.mesh.compute_quadrature(quadpy.c2.schemes['sommariva_01']())
     data_1 = solver.fill_dataset(test_matrix, [cylinder], mesh=True)
 
-    cylinder.mesh.compute_quadrature(quadpy.quadrilateral.sommariva_03())
+    cylinder.mesh.compute_quadrature(quadpy.c2.schemes['sommariva_03']())
     data_3 = solver.fill_dataset(test_matrix, [cylinder], mesh=True)
 
     assert data_1['quadrature_method'] == "Sommariva 1"

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ if __name__ == "__main__":
               'meshio',
               'pygmsh',
               'gmsh',
-              'quadpy<=0.14.11',
               'bemio @ git+https://github.com/michaelcdevin/bemio.git@master-python3#egg=bemio',
               'sphinx',
               'sphinxcontrib-proof',
@@ -109,7 +108,6 @@ if __name__ == "__main__":
               'meshio',
               'pygmsh',
               'gmsh',
-              'quadpy<=0.14.11',
               'bemio @ git+https://github.com/michaelcdevin/bemio.git@master-python3#egg=bemio',
             ]
           },

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ if __name__ == "__main__":
               'meshio',
               'pygmsh',
               'gmsh',
+              'quadpy',
               'bemio @ git+https://github.com/michaelcdevin/bemio.git@master-python3#egg=bemio',
               'sphinx',
               'sphinxcontrib-proof',
@@ -108,6 +109,7 @@ if __name__ == "__main__":
               'meshio',
               'pygmsh',
               'gmsh',
+              'quadpy',
               'bemio @ git+https://github.com/michaelcdevin/bemio.git@master-python3#egg=bemio',
             ]
           },


### PR DESCRIPTION
A breaking change after quadpy 0.14 make recent versions of quadpy incompatible with the quadrature computation in Capytaine.
This P.R. updates Capytaine to be compatible with the latest version of quadpy (version 0.16.16).

Fixes #48. For now at least, I'm not sure what is happening with quadpy repository recently...

Also, this P.R. improves the documentation of the quadrature computation.