### PR TITLE
Renaming 'mass' to 'inertia_matrix'

### DIFF
--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -184,11 +184,11 @@ def wavenumber_data_array(results: Sequence[LinearPotentialFlowResult]) -> xr.Da
 
 
 def hydrostatics_dataset(bodies: Sequence[FloatingBody]) -> xr.Dataset:
-    """Create a dataset by looking for 'mass' and 'hydrostatic_stiffness'
+    """Create a dataset by looking for 'inertia_matrix' and 'hydrostatic_stiffness'
     for each of the bodies in the list passed as argument.
     """
     dataset = xr.Dataset()
-    for body_property in ['mass', 'hydrostatic_stiffness']:
+    for body_property in ['inertia_matrix', 'hydrostatic_stiffness']:
         bodies_properties = {body.name: body.__getattribute__(body_property) for body in bodies if hasattr(body, body_property)}
         if len(bodies_properties) > 0:
             bodies_properties = xr.concat(bodies_properties.values(), pd.Index(bodies_properties.keys(), name='body_name'))

--- a/capytaine/post_pro/impedance.py
+++ b/capytaine/post_pro/impedance.py
@@ -19,7 +19,7 @@ def rao_transfer_function(dataset, dissipation=None, stiffness=None):
     ----------
     dataset: xarray Dataset
         The hydrodynamical dataset.
-        This function supposes that variables named 'mass' and 'hydrostatic_stiffness' are in the dataset.
+        This function supposes that variables named 'inertia_matrix' and 'hydrostatic_stiffness' are in the dataset.
         Other variables can be computed by Capytaine, by those two should be manually added to the dataset.
     dissipation: array, optional
         An optional dissipation matrix (e.g. Power Take Off) to be included in the transfer function.
@@ -34,8 +34,8 @@ def rao_transfer_function(dataset, dissipation=None, stiffness=None):
         The matrix as an array depending of omega and the degrees of freedom.
     """
 
-    if not hasattr(dataset, 'mass'):
-        raise AttributeError('Computing the impedance matrix requires a :code:`mass` matrix to be defined in the hydrodynamical dataset')
+    if not hasattr(dataset, 'inertia_matrix'):
+        raise AttributeError('Computing the impedance matrix requires a :code:`inertia_matrix` matrix to be defined in the hydrodynamical dataset')
 
     if not hasattr(dataset, 'hydrostatic_stiffness'):
         raise AttributeError('Computing the impedance matrix requires a :code:`hydrostatic_stiffness` matrix to be defined in the hydrodynamical dataset')
@@ -43,7 +43,7 @@ def rao_transfer_function(dataset, dissipation=None, stiffness=None):
     # ASSEMBLE MATRICES
     omega = dataset.coords['omega']  # Range of frequencies in the dataset
 
-    H = (-omega**2*(dataset['mass'] + dataset['added_mass'])
+    H = (-omega**2*(dataset['inertia_matrix'] + dataset['added_mass'])
          - 1j*omega*dataset['radiation_damping']
          + dataset['hydrostatic_stiffness'])
 
@@ -73,7 +73,7 @@ def impedance(dataset, dissipation=None, stiffness=None):
     ----------
     dataset: xarray Dataset
         The hydrodynamical dataset.
-        This function supposes that variables named 'mass' and 'hydrostatic_stiffness' are in the dataset.
+        This function supposes that variables named 'inertia_matrix' and 'hydrostatic_stiffness' are in the dataset.
         Other variables can be computed by Capytaine, by those two should be manually added to the dataset.
     dissipation: array, optional
         An optional dissipation matrix (e.g. Power Take Off) to be included in the impedance.

--- a/capytaine/post_pro/rao.py
+++ b/capytaine/post_pro/rao.py
@@ -20,7 +20,7 @@ def rao(dataset, wave_direction=0.0, dissipation=None, stiffness=None):
     ----------
     dataset: xarray Dataset
         The hydrodynamical dataset.
-        This function supposes that variables named 'mass' and 'hydrostatic_stiffness' are in the dataset.
+        This function supposes that variables named 'inertia_matrix' and 'hydrostatic_stiffness' are in the dataset.
         Other variables can be computed by Capytaine, by those two should be manually added to the dataset.
     wave_direction: float, optional
         The direction of the incoming waves.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* The function that used to be called :code:`impedance` is now named :func:`~capytaine.post_pro.impedance.rao_transfer_function`.
+  The new function :func:`~capytaine.post_pro.impedance.impedance` is the actual impedance matrix (:pull:`142`, :issue:`147`, :pull:`149`).
+
+* The mass matrix of a floating body used to be denoted :code:`mass`. It is now denote :code:`inertia_matrix`.
+  The attribute :code:`body.mass` is now used instead for the (scalar) mass of the body. (:pull:`165`)
+
+Other changes
+~~~~~~~~~~~~~
+
 * Fix major bug in impedance matrix and RAO computation: the sign of the
   dissipation matrix was wrong in previous versions (:issue:`102` and
   :pull:`140`).
@@ -9,9 +21,6 @@ Changelog
 * Fix major inaccuracy for deep panels or high frequencies, that is panels deeper than :math:`1.2\lambda` below the free surface where :math:`\lambda` is the wavelength (:issue:`38` and :pull:`156`)
 
 * Refactor Delhommeau's method for the Green function evaluation. The size of the tabulation is not hard-coded anymore and can be changed by users. (:issue:`20` and :pull:`157`)
-
-* Correct the function :func:`~capytaine.post_pro.impedance.impedance` to actually return the impedance matrix.
-  The former behavior has been renamed as :func:`~capytaine.post_pro.impedance.rao_transfer_function`. (:pull:`142`, :issue:`147`, :pull:`149`).
 
 * Method :code:`show_matplotlib` can now colour mesh faces based on a
   specified scalar field (e.g. pressure) (:pull:`122`).

--- a/docs/user_manual/examples/boat_animation.py
+++ b/docs/user_manual/examples/boat_animation.py
@@ -21,7 +21,7 @@ def generate_boat() -> cpt.FloatingBody:
 
     # Compute hydrostatics
     boat.hydrostatic_stiffness = boat.compute_hydrostatic_stiffness()
-    boat.mass = boat.compute_rigid_body_inertia()
+    boat.inertia_matrix = boat.compute_rigid_body_inertia()
     return boat
 
 

--- a/docs/user_manual/hydrostatics.rst
+++ b/docs/user_manual/hydrostatics.rst
@@ -99,19 +99,19 @@ Inertia matrix
 --------------
 
 The method :meth:`~capytaine.bodies.FloatingBody.compute_rigid_body_inertia` is
-able to computes the 6 x 6 inertia mass matrix of a body with 6 rigid dofs.
+able to computes the 6 x 6 inertia matrix of a body with 6 rigid dofs.
 The inertia coefficient of other degrees of freedom are filled with :code:`NaN` by default.
 
 ::
 
-    rigid_sphere.mass = elastic_sphere.compute_rigid_body_inertia()
+    rigid_sphere.inertia_matrix = elastic_sphere.compute_rigid_body_inertia()
 
 
 A custom matrix can be provided. For consistency with the data computed with
 Capytaine, it is recommended to wrap it in a :code:`xarray.DataArray` with dof
 names as labels::
 
-    elastic_sphere.mass = elastic_sphere.add_dofs_labels_to_matrix(np.array([[1000.0]]))
+    elastic_sphere.inertia_matrix = elastic_sphere.add_dofs_labels_to_matrix(np.array([[1000.0]]))
 
 
 Compute all hydrostatics parameters

--- a/docs/user_manual/outputs.rst
+++ b/docs/user_manual/outputs.rst
@@ -74,8 +74,8 @@ then called by `assemble_dataset`. For example, to create an xarray dataset from
              differences between the variable names in an xarray dataset build with Bemio and one created
              using :code:`LinearPotentialFlowResult`, even though the format will be identical. For
              example, WAMIT :code:`.out` files do not contain the radii of gyration needed to calculate
-             the moments of inertia, so the `my_dataset['mass']` variable would not be included in the above
-             example since the rigid body mass matrix cannot be calculated.
+             the moments of inertia, so the `my_dataset['inertia_matrix']` variable would not be included 
+             in the above example since the rigid body mass matrix cannot be calculated.
 
 Saving the dataset as NetCDF file
 ---------------------------------

--- a/docs/user_manual/post_pro.rst
+++ b/docs/user_manual/post_pro.rst
@@ -52,7 +52,7 @@ hydrostatics, and inertial properties::
     sphere.center_of_mass = np.array([0, 0, 0])
     sphere.add_all_rigid_body_dofs()
 
-    sphere.mass = sphere.compute_rigid_body_inertia(rho=rho_water)
+    sphere.inertia_matrix = sphere.compute_rigid_body_inertia(rho=rho_water)
     sphere.hydrostatic_stiffness = sphere.compute_hydrostatic_stiffness(rho=rho_water)
 
     solver = BEMSolver()
@@ -74,7 +74,7 @@ hydrostatics, and inertial properties::
 
 
 
-Note that we assigned the inertia and stiffness to attributes of :code:`body` called :code:`mass` and :code:`hydrostatic_stiffness`.
+Note that we assigned the inertia and stiffness to attributes of :code:`body` called :code:`inertia_matrix` and :code:`hydrostatic_stiffness`.
 These are the names expected by the :code:`fill_dataset` and :code:`impedance` functions to compute the impedance matrix.
 
 By simple extension of incorporating the excitation transfer function response

--- a/pytest/test_post_pro.py
+++ b/pytest/test_post_pro.py
@@ -1,4 +1,4 @@
-import pytest 
+import pytest
 import numpy as np
 import xarray as xr
 from capytaine import BEMSolver
@@ -14,37 +14,37 @@ m = 1.866e+03
 
 M = np.array([
        [ m,  0.000e+00,  0.000e+00,  0.000e+00,  0.000e+00,  0.000e+00],
-       [ 0.000e+00,  1.866e+03,  0.000e+00,  0.000e+00,  0.000e+00,  0.000e+00],
-       [ 0.000e+00,  0.000e+00,  1.866e+03,  0.000e+00,  0.000e+00,  0.000e+00],
+       [ 0.000e+00,  m,  0.000e+00,  0.000e+00,  0.000e+00,  0.000e+00],
+       [ 0.000e+00,  0.000e+00,  m,  0.000e+00,  0.000e+00,  0.000e+00],
        [ 0.000e+00,  0.000e+00,  0.000e+00,  4.469e+02,  9.676e-31, -2.757e-14],
        [ 0.000e+00,  0.000e+00,  0.000e+00,  9.676e-31,  4.469e+02,  3.645e-15],
        [ 0.000e+00,  0.000e+00,  0.000e+00, -2.757e-14,  3.645e-15,  6.816e+02]])
 
 kHS = np.array([
-	[    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ],
-   	[    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ],
-   	[    0.   ,     0.   , 29430.   ,     0.   ,     0.   ,     0.   ],
-   	[    0.   ,     0.   ,     0.   ,   328.573,     0.   ,     0.   ],
-   	[    0.   ,     0.   ,     0.   ,     0.   ,   328.573,     0.   ],
-   	[    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ]])
+    [    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ],
+    [    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ],
+    [    0.   ,     0.   , 29430.   ,     0.   ,     0.   ,     0.   ],
+    [    0.   ,     0.   ,     0.   ,   328.573,     0.   ,     0.   ],
+    [    0.   ,     0.   ,     0.   ,     0.   ,   328.573,     0.   ],
+    [    0.   ,     0.   ,     0.   ,     0.   ,     0.   ,     0.   ]])
+
 
 @pytest.fixture
 def sphere_fb():
-
     sphere = Sphere(radius=r, ntheta=3, nphi=12, clip_free_surface=True)
     sphere.add_all_rigid_body_dofs()
 
-    sphere.mass = sphere.add_dofs_labels_to_matrix(M)
+    sphere.inertia_matrix = sphere.add_dofs_labels_to_matrix(M)
     sphere.hydrostatic_stiffness = sphere.add_dofs_labels_to_matrix(kHS)
 
     return sphere
 
 def test_rao_sphere_all(sphere_fb):
 
-    solver = BEMSolver()                
+    solver = BEMSolver()
     test_matrix = xr.Dataset(coords={
-        'rho': rho_water,                         
-        'water_depth': [np.infty],          
+        'rho': rho_water,
+        'water_depth': [np.infty],
         'omega': omega,
         'wave_direction': 0,
         'radiating_dof': list(sphere_fb.dofs.keys()),
@@ -59,8 +59,8 @@ def test_rao_sphere_all(sphere_fb):
     RAO = rao(data)
 
     assert RAO.radiating_dof.size == 6
-    assert data.mass.shape == (6,6)
-    assert np.all(data.mass.values == M)
+    assert data.inertia_matrix.shape == (6,6)
+    assert np.all(data.inertia_matrix.values == M)
     assert data.hydrostatic_stiffness.shape == (6,6)
     assert np.all(data.hydrostatic_stiffness.values == kHS)
     # # assert RAO == ? # TODO could test against known results
@@ -69,11 +69,10 @@ def test_rao_sphere_all(sphere_fb):
 def sphere_heave_data(sphere_fb):
     sphere_fb.keep_only_dofs(['Heave'])
 
-
-    solver = BEMSolver()                
+    solver = BEMSolver()
     test_matrix = xr.Dataset(coords={
-          'rho': rho_water,                         
-          'water_depth': [np.infty],          
+          'rho': rho_water,
+          'water_depth': [np.infty],
           'omega': omega,
           'wave_direction': 0,
           'radiating_dof': list(sphere_fb.dofs.keys()),
@@ -90,13 +89,12 @@ def sphere_heave_data(sphere_fb):
 def test_impedance_sphere_heave(sphere_heave_data):
     Zi = impedance(sphere_heave_data)
 
+
 def test_rao_sphere_heave_indirect(sphere_heave_data):
-
     RAO = rao(sphere_heave_data)
-
     assert RAO.radiating_dof.size == 1
-    assert sphere_heave_data.mass.size == 1
-    assert sphere_heave_data.mass.values == m
+    assert sphere_heave_data.inertia_matrix.size == 1
+    assert sphere_heave_data.inertia_matrix.values == m
     assert sphere_heave_data.hydrostatic_stiffness.size == 1
     assert sphere_heave_data.hydrostatic_stiffness.values == kHS[2,2]
     # assert RAO == ? # TODO could test against known results


### PR DESCRIPTION
Following a discussion in #154, reverting a decision made in #56.

Even if it is a breaking change, I think it makes more sense to have `mass` to denote the scalar mass of the body and to have instead `inertia_matrix` for the mass matrix.
It is also more consistent with the name `compute_rigid_body_inertia` (and not `compute_rigid_body_mass`) implemented in #106.
For a flexible body, the inertia matrix might be barely related to the mass of the body, so naming it `mass` might be confusing.