### PR TITLE
Fix installation of Capytaine with pip when Numpy is missing

### DIFF
--- a/docs/user_manual/installation.rst
+++ b/docs/user_manual/installation.rst
@@ -53,4 +53,5 @@ If you do, you can install Capytaine as::
 If you can't install a compiler, it is recommended to use Conda instead.
 
 .. [#] For example, on Ubuntu or Debian: :code:`sudo apt install gfortran`.
+       On macOS, see `for instance these instructions <https://github.com/mancellin/capytaine/issues/115#issuecomment-1143987636>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 # coding: utf-8
 
 import os
+
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(['numpy'])
+
 from numpy.distutils.core import Extension, setup
 
 ########################


### PR DESCRIPTION
Fix #112, thanks to @cmichelenstrofer.
Also add a link to the installation instructions for macOS https://github.com/mancellin/capytaine/issues/115#issuecomment-1143987636.