### PR TITLE
Use direct linear solver as default.

### DIFF
--- a/capytaine/bem/engines.py
+++ b/capytaine/bem/engines.py
@@ -52,7 +52,7 @@ class BasicMatrixEngine(MatrixEngine):
     linear_solver: str or function, optional
         Setting of the numerical solver for linear problems Ax = b.
         It can be set with the name of a preexisting solver
-        (available: "direct" and "gmres", the latter is the default choice)
+        (available: "direct" and "gmres", the former is the default choice)
         or by passing directly a solver function.
     matrix_cache_size: int, optional
         number of matrices to keep in cache
@@ -61,7 +61,7 @@ class BasicMatrixEngine(MatrixEngine):
     available_linear_solvers = {'direct': linear_solvers.solve_directly,
                                 'gmres': linear_solvers.solve_gmres}
 
-    def __init__(self, *, linear_solver='gmres', matrix_cache_size=1):
+    def __init__(self, *, linear_solver='direct', matrix_cache_size=1):
 
         if linear_solver in self.available_linear_solvers:
             self.linear_solver = self.available_linear_solvers[linear_solver]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@ Breaking changes
 * The mass matrix of a floating body used to be denoted :code:`mass`. It is now denote :code:`inertia_matrix`.
   The attribute :code:`body.mass` is now used instead for the (scalar) mass of the body. (:pull:`165`)
 
+* The default linear solver is the direct solver and not the iterative solver GMRES, because it is more robust and more predictable.
+  Nothing changes when user explicitely chose a linear solver. (:pull:`171`:)
+
 Other changes
 ~~~~~~~~~~~~~
 

--- a/docs/user_manual/resolution.rst
+++ b/docs/user_manual/resolution.rst
@@ -45,10 +45,13 @@ Two of them are available in the present version:
            Setting it to :code:`0` will reduce the RAM usage of the code but might
            increase the computation time.
 
-   :code:`linear_solver` (Default: :code:`'gmres'`)
+   :code:`linear_solver` (Default: :code:`'direct'`)
            This option is used to set the solver for linear systems that is used in the resolution of the BEM problem.
            Passing a string will make the code use one of the predefined solver. Two of them are available:
            :code:`'direct'` for a direct solver using LU-decomposition or :code:`'gmres'` for an iterative solver.
+
+           The former is used by default (since version 1.4) because it is more robust and the computation time is more predictable.
+           Advanced users might want to change the solver to :code:`gmres`, which is faster in many situations (and completely fails in other).
 
            Alternatively, any function taking as arguments a matrix and a vector and returning a vector can be given to the solver::
 

--- a/pytest/test_bem_hierarchical_toeplitz_matrices.py
+++ b/pytest/test_bem_hierarchical_toeplitz_matrices.py
@@ -97,8 +97,8 @@ def test_two_vertical_cylinders():
     assert np.isclose(results['radiation_damping'].data[0, 1, 0], results['radiation_damping'].data[0, 0, 1])
 
     results_with_sym = assemble_dataset(solver_with_sym.solve_all(problems))
-    assert np.allclose(results['added_mass'].data, results_with_sym['added_mass'].data)
-    assert np.allclose(results['radiation_damping'].data, results_with_sym['radiation_damping'].data)
+    assert np.allclose(results['added_mass'].data, results_with_sym['added_mass'].data, rtol=1e-3)
+    assert np.allclose(results['radiation_damping'].data, results_with_sym['radiation_damping'].data, rtol=1e-3)
 
 
 def test_odd_axial_symmetry():

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -32,7 +32,7 @@ def test_exportable_settings():
     engine = BasicMatrixEngine(matrix_cache_size=0)
     assert engine.exportable_settings['engine'] == 'BasicMatrixEngine'
     assert engine.exportable_settings['matrix_cache_size'] == 0
-    assert engine.exportable_settings['linear_solver'] == 'gmres'
+    assert engine.exportable_settings['linear_solver'] == 'direct'
 
     solver = BEMSolver(green_function=gf, engine=engine)
     assert solver.exportable_settings['green_function'] == 'Delhommeau'
@@ -40,7 +40,7 @@ def test_exportable_settings():
     assert solver.exportable_settings['finite_depth_prony_decomposition_method'] == 'fortran'
     assert solver.exportable_settings['engine'] == 'BasicMatrixEngine'
     assert solver.exportable_settings['matrix_cache_size'] == 0
-    assert solver.exportable_settings['linear_solver'] == 'gmres'
+    assert solver.exportable_settings['linear_solver'] == 'direct'
 
 
 def test_limit_frequencies():


### PR DESCRIPTION
Kinda fixing #30 as well as one of the issues in #50.
The GMRES linear solver currently used as default is faster in most cases but fails to converge in some edge cases (e.g. irregular frequencies).
Using the direct solver slightly decreases the performance but the solver is more robust and the computation time more predictable.
This PR change the default solver, but both are still available to advanced users.