### PR TITLE
Disable joblib by default.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Other changes
   specified scalar field (e.g. pressure) (:pull:`122`).
 
 * Add new parallelization using the `joblib <https://joblib.readthedocs.io>`_ library as a new optional dependency.
-  The optional keyword-argument :code:`n_jobs` in the :meth:`~capytaine.bem.solver.BEMSolver.solve_all` and :meth:`~capytaine.bem.solver.BEMSolver.fill_dataset` controls the number of processes running in parallel (:pull:`136`).
+  The optional keyword-argument :code:`n_jobs` in the :meth:`~capytaine.bem.solver.BEMSolver.solve_all` and :meth:`~capytaine.bem.solver.BEMSolver.fill_dataset` controls the number of processes running in parallel (:pull:`136`). By default, this parallelisation is disabled (:pull:`172`).
 
 * A new example using Haskind's relation has been added to the cookbook (:pull:`129`).
 

--- a/docs/user_manual/resolution.rst
+++ b/docs/user_manual/resolution.rst
@@ -149,13 +149,15 @@ feature (new in version 1.4) requires the optional dependency `joblib
 :meth:`~capytaine.bem.solver.BEMSolver.fill_dataset` take an optional
 keyword-argument :code:`n_jobs` which control the number of jobs to run in
 parallel during the batch resolution.
+Since `joblib` may disturb user feedback (logging and error
+reporting), it is currently disabled by default.
 
-When :code:`n_jobs=-1` (the default when `joblib` is installed), all CPU
-cores are used (and `joblib` should automatically disable the OpenMP
-parallelization.)
+When :code:`n_jobs=1` (the default) or `joblib` is not installed, no parallel
+batch resolution happens (although OpenMP parallelization might still be
+enabled).
 
-When :code:`joblib` is not installed or :code:`n_jobs=1`, no parallel batch
-resolution happens (although OpenMP parallelization might still be enabled).
+When :code:`n_jobs=-1`, all CPU cores are used (and `joblib` should
+automatically disable the OpenMP parallelization.)
 
 The two parallelization layers (OpenMP and `joblib`) have different usage. If
 you have a relatively small mesh but study a large number of sea states, you


### PR DESCRIPTION
The parallelisation with joblib is a new feature of version 1.4. In the original implementation #136, it was enabled by default.

After a few weeks of usage, I noticed that joblib disturbs the feedback to users (logging and error reporting might be missing, e.g. #148). It may be disturbing for new users to have a different feedback depending on the installation of some obscure Python package in their environment.

Thus, I prefer to disable it by default, until the user feedback issues have been fixed and the use of the package is totally transparent for users. For now, it will be used only for users explicitly asking for it.